### PR TITLE
Fix/update plugin for proto3 and newest doxygen

### DIFF
--- a/protoc-gen-dox.py
+++ b/protoc-gen-dox.py
@@ -17,6 +17,7 @@ LOCATION_VALUE_TYPE = 2
 LOCATION_ONEOF_TYPE = 8
 
 if sys.version_info >= (3, 0):
+    unicode = str
     STDERR_STREAM = sys.stderr.buffer
     STDIN_STREAM  = sys.stdin.buffer
     STDOUT_STREAM = sys.stdout.buffer
@@ -58,10 +59,10 @@ def html_col(text, **kwargs):
         doc += " " + key + "=\"" + str(value) + "\""
     doc += ">"
 
-    if isinstance(text, str):
+    if isinstance(text, unicode) or isinstance(text, str):
         doc += text
     elif isinstance(text, bytes):
-        doc += text.decode()
+        doc += text.decode('utf-8')
     else:
         doc += str(text)
     doc += "</td>\n"

--- a/protoc-gen-dox.py
+++ b/protoc-gen-dox.py
@@ -109,7 +109,7 @@ def protobuf_type2desc(field_desc):
     elif field_desc.type == desc.TYPE_ENUM:
         return "@ref " + field_desc.type_name[1:]
     elif field_desc.type == desc.TYPE_FIELD_NUMBER:
-        return ""
+        return "int32"
     elif field_desc.type == desc.TYPE_FIXED32:
         return "fixed point 32"
     elif field_desc.type == desc.TYPE_FIXED64:

--- a/protoc-gen-dox.py
+++ b/protoc-gen-dox.py
@@ -147,7 +147,7 @@ class ProtoDox(object):
     each undocument element return "No doc string !"
     """
     def __init__(self, name, prefix=""):
-        self._basename = name.split('.', 1)[0]
+        self._basename = name.split('.', 1)[0].replace('/', '_')
         self._name = ""
         if prefix:
             self._name += prefix + "."
@@ -263,7 +263,7 @@ class ProtoMessageDox(ProtoDox):
             elem.set_elem_doc_string(location, index_offset + 2)
 
     def to_doxygen(self):
-        doc = ""
+        doc = "\\n" # to nicely separate messages/enum in html output
 
         if self._nested:
             doc += add_doxygen_cmd("subsubsection", self._basename)
@@ -341,7 +341,7 @@ class ProtoEnumDox(ProtoDox):
             elem.set_doc_string(doc_string)
 
     def to_doxygen(self):
-        doc = ""
+        doc = "\\n" # to separate nicely messages/enum in html output
 
         if self._nested:
             doc += add_doxygen_cmd("subsubsection", self._basename)
@@ -415,6 +415,7 @@ class ProtoFileDox(ProtoDox):
         self._doc_string += add_doxygen_cmd("page", self._name)
         self._doc_string += add_doxygen_cmd("tableofcontents", "")
         self._doc_string += add_doxygen_cmd("section", self._basename)
+        self._doc_string += add_doxygen_cmd("brief", "   ")
 
         for enum in self._enums:
             self._doc_string += enum.to_doxygen()

--- a/protoc-gen-dox.py
+++ b/protoc-gen-dox.py
@@ -58,10 +58,12 @@ def html_col(text, **kwargs):
         doc += " " + key + "=\"" + str(value) + "\""
     doc += ">"
 
-    if isinstance(text, unicode) or isinstance(text, str):
+    if isinstance(text, str):
         doc += text
+    elif isinstance(text, bytes):
+        doc += text.decode()
     else:
-        doc += str(text).encode('utf-8')
+        doc += str(text)
     doc += "</td>\n"
 
     return doc


### PR DESCRIPTION
I made some modifications to make the plugin works with python 3.8
- remove of 'unicode' function of python 2.7
- remove of unwanted encoding
- add decoding of text if it is in bytes

Dox enhancement:
- Fix a bug that displays the brief of the first message of a proto file as the breif of the file section
- Add a newline between messages for more readability inhtml output
- Fix a bug by removing '/' in dox section name (replaced by '_')

TODO :
- update README with how-to and examples
- check python 2.7 compatibility
